### PR TITLE
show all output in red when errors are encountered running in cucumber

### DIFF
--- a/features/step_definitions/git_immersion_testing_steps.rb
+++ b/features/step_definitions/git_immersion_testing_steps.rb
@@ -8,7 +8,7 @@ def run_ag(subject, spec)
   run_process cli_string
 end
 
-def run_process(cli_string, dir='rag')
+def run_process(cli_string, dir=@autograders)
   @test_output, @test_errors, @test_status = Open3.capture3(
       { 'BUNDLE_GEMFILE' => 'Gemfile' }, cli_string, :chdir => dir
   )

--- a/features/step_definitions/git_immersion_testing_steps.rb
+++ b/features/step_definitions/git_immersion_testing_steps.rb
@@ -5,10 +5,22 @@ def run_ag(subject, spec)
   git_user = IO.read(subject)
   cli_string = "./new_grader -t GithubRspecGrader #{git_user} ../#{spec}"
   cli_string = cli_string.gsub("\n", ' ')
-  @test_output, @test_errors, @test_status = Open3.capture3(
-      { 'BUNDLE_GEMFILE' => 'Gemfile' }, cli_string, :chdir => @autograders
-  )
+  run_process cli_string
 end
+
+def run_process(cli_string, dir='rag')
+  @test_output, @test_errors, @test_status = Open3.capture3(
+      { 'BUNDLE_GEMFILE' => 'Gemfile' }, cli_string, :chdir => dir
+  )
+  show_errors
+end
+
+def show_errors
+  if @test_errors.empty? == false && @test_status.success? == false
+    expect(@test_output + @test_errors + @test_status.to_s).to eql ''
+  end
+end
+
 
 
 Given(/^I have the homework in "(.*?)"$/) do |hw|
@@ -41,14 +53,4 @@ end
 And(/^I should see the execution results with (.*)$/) do |test_title|
   success = @test_status.success? ? 'Success' : 'Failure'
   puts success + '!'
-end
-
-Then(/^I should see that there are no errors$/) do
-  expect(@test_status).to be_success
-end
-
-Then(/I should see the execution results$/) do
-  puts @test_status
-  puts @test_errors
-  puts @test_output
 end

--- a/install/install.feature
+++ b/install/install.feature
@@ -6,18 +6,14 @@ Feature: Installation of dependencies
   Scenario: Install gems
     Given that I am in the project root directory "AutoGraderExamples"
     When I install gems
-    #Then I should see 25 gems
-    And I should see that there are no errors
+    Then I should see that there are no errors
 
   Scenario: Install or check AutoGraders
     Given that I am in the project root directory "AutoGraderExamples"
     When I install or check "saasbook/rag" as "rag"
     And I change to branch "develop"
     And I install the AutoGrader gems
-    # Debug:
-    Then I should see the execution results
-    #And I should see 74 gems
-    And I should see that there are no errors
+    Then I should see that there are no errors
 
   Scenario: Verify correct version of AutoGraders
     Given I go to the AutoGrader directory "rag"

--- a/install/install_steps.rb
+++ b/install/install_steps.rb
@@ -1,8 +1,26 @@
 require 'open3'
 
 def run_in_dir(arg_string, dir=@dir)
-  @test_output, @test_errors, @test_status = Open3.capture3(arg_string, :chdir => dir)
-  puts @test_errors if @test_errors != ''
+  run_process(arg_string, dir, false)
+end
+
+def run_process(cli_string, dir='.', gemfile=false)
+  if gemfile
+    @test_output, @test_errors, @test_status = Open3.capture3(
+        { 'BUNDLE_GEMFILE' => 'Gemfile' }, cli_string, :chdir => dir
+    )
+  else
+    @test_output, @test_errors, @test_status = Open3.capture3(
+        cli_string, :chdir => dir
+    )
+  end
+  show_errors
+end
+
+def show_errors
+  if @test_errors.empty? == false && @test_status.success? == false
+    expect(@test_output + @test_errors + @test_status.to_s).to eql ''
+  end
 end
 
 
@@ -29,15 +47,13 @@ end
 
 When(/^I install gems$/) do
   @dir = Dir.getwd
-  @test_output, @test_errors, @test_status = Open3.capture3(
-      { 'BUNDLE_GEMFILE' => 'Gemfile' }, 'bundle install'
-  )
+  run_process 'bundle install', '.', true
 end
 
 When(/^I install or check "(.*)" as "(.*)"$/) do |repo, dir|
   if ! Dir.exists?(dir)
     puts "Clone AutoGraders as '#{dir}'"
-    @test_output, @test_errors, @test_status = Open3.capture3("git clone https://github.com/#{repo} #{dir}" )
+    run_process("git clone https://github.com/#{repo} #{dir}" )
   else
     puts "Existing '#{dir}'. Skip clone, fetch instead."
     run_in_dir("git fetch origin", dir )
@@ -56,9 +72,7 @@ When(/^I change to branch "(.*?)"$/) do |branch|
 end
 
 And(/^I install the AutoGrader gems$/) do
-  @test_output, @test_errors, @test_status = Open3.capture3(
-      { 'BUNDLE_GEMFILE' => 'Gemfile' }, 'bundle install', :chdir => @dir
-  )
+  run_process('bundle install', @dir, true)
 end
 
 ## Then Steps
@@ -71,9 +85,7 @@ end
 
 
 And(/^I should see (\d+) gems$/) do |num|
-  @test_output, @test_errors, @test_status = Open3.capture3(
-      { 'BUNDLE_GEMFILE' => 'Gemfile' }, 'bundle list', :chdir => @dir
-  )
+  run_process('bundle list', @dir, true)
   expect(@test_output.lines.select{|x| x.match /\*/}).to have(num).gems
 end
 

--- a/install/install_steps.rb
+++ b/install/install_steps.rb
@@ -83,20 +83,6 @@ Then(/^I should see no difference$/) do
   #puts "'#{@dir}' matches origin/#{@branch} branch"
 end
 
-
-And(/^I should see (\d+) gems$/) do |num|
-  run_process('bundle list', @dir, true)
-  expect(@test_output.lines.select{|x| x.match /\*/}).to have(num).gems
-end
-
-# duplicate steps from hw_testing_steps
-
 Then(/^I should see that there are no errors$/) do
   expect(@test_status).to be_success
-end
-
-Then(/I should see the execution results$/) do
-  puts @test_status
-  puts @test_errors
-  puts @test_output
 end


### PR DESCRIPTION
- same as https://github.com/saasbook/hw/pull/26
- Eliminate some mystery errors that say `expected "" to match "some expected output"` 
- Uses an expectation to get red text
- Refactoring in install_steps
