### PR TITLE
cleanup and refactor features and steps

### DIFF
--- a/features/git_immersion_testing.feature
+++ b/features/git_immersion_testing.feature
@@ -5,9 +5,7 @@ Feature: Testing instructor created homeworks
 
   Scenario Outline: The project is set up and runs correctly
     Given I have the homework in "git-immersion"
-    # And gems are installed
     And AutoGraders are in "rag"
-    # And AutoGrader gems are installed
     When I run AutoGrader for <test_subject> and <spec>
     Then I should see that the results are <expected_result>
     And I should see the execution results with <test_title>

--- a/features/step_definitions/git_immersion_testing_steps.rb
+++ b/features/step_definitions/git_immersion_testing_steps.rb
@@ -1,10 +1,9 @@
 require 'open3'
 
 def run_ag(subject, spec)
-  expect(@hw_path).not_to be_nil
-  git_user = IO.read(subject)
+  git_user = File.read(subject).strip
   cli_string = "./new_grader -t GithubRspecGrader #{git_user} ../#{spec}"
-  cli_string = cli_string.gsub("\n", ' ')
+  #cli_string = cli_string.gsub("\n", ' ')
   run_process cli_string
 end
 
@@ -12,27 +11,12 @@ def run_process(cli_string, dir=@autograders)
   @test_output, @test_errors, @test_status = Open3.capture3(
       { 'BUNDLE_GEMFILE' => 'Gemfile' }, cli_string, :chdir => dir
   )
-  show_errors
+  raise ( @test_output + @test_errors + @test_status.to_s ) unless @test_status.success?
 end
-
-def show_errors
-  if @test_errors.empty? == false && @test_status.success? == false
-    expect(@test_output + @test_errors + @test_status.to_s).to eql ''
-  end
-end
-
-
 
 Given(/^I have the homework in "(.*?)"$/) do |hw|
   @hw_path = hw
   expect(Dir).to exist(@hw_path)
-end
-
-Given(/^gems are installed$/) do
-  @test_output, @test_errors, @test_status = Open3.capture3(
-      { 'BUNDLE_GEMFILE' => 'Gemfile' }, 'bundle install', :chdir => @hw_path
-  )
-  expect(@test_errors).to be_empty
 end
 
 Given(/^AutoGraders are in "(.*)"$/) do |rag|
@@ -43,8 +27,6 @@ end
 When(/^I run AutoGrader for (.*) and (.*)$/) do |test_subject, spec|
   run_ag("#{@hw_path}/#{test_subject}", "#{@hw_path}/#{spec}")
 end
-
-## Then steps
 
 Then(/^I should see that the results are (.*)$/) do |expected_result|
   expect(@test_output).to match /#{expected_result}/

--- a/install/install.feature
+++ b/install/install.feature
@@ -6,18 +6,14 @@ Feature: Installation of dependencies
   Scenario: Install gems
     Given that I am in the project root directory "AutoGraderExamples"
     When I install gems
-    #Then I should see 25 gems
-    And I should see that there are no errors
+    Then I should see that there are no errors
 
   Scenario: Install or check AutoGraders
     Given that I am in the project root directory "AutoGraderExamples"
     When I install or check "saasbook/rag" as "rag"
     And I change to branch "develop"
     And I install the AutoGrader gems
-    # Debug:
-    Then I should see the execution results
-    #And I should see 74 gems
-    And I should see that there are no errors
+    Then I should see that there are no errors
 
   Scenario: Verify correct version of AutoGraders
     Given I go to the AutoGrader directory "rag"

--- a/install/install_steps.rb
+++ b/install/install_steps.rb
@@ -14,17 +14,8 @@ def run_process(cli_string, dir='.', gemfile=false)
         cli_string, :chdir => dir
     )
   end
-  show_errors
+  raise ( @test_output + @test_errors + @test_status.to_s ) unless @test_status.success?
 end
-
-def show_errors
-  if @test_errors.empty? == false && @test_status.success? == false
-    expect(@test_output + @test_errors + @test_status.to_s).to eql ''
-  end
-end
-
-
-## Given Steps
 
 Given /^that I am in the project root directory "(.*?)"$/ do |project_dir|
   @project_dir = project_dir
@@ -41,9 +32,6 @@ Given(/^it has an origin of "(.*?)"$/) do |origin|
   @test_output = @test_output.gsub('.git', '')
   expect(@test_output).to match(/origin\t#{origin} \(fetch\)/)
 end
-
-
-## When Steps
 
 When(/^I install gems$/) do
   @dir = Dir.getwd
@@ -71,32 +59,15 @@ When(/^I change to branch "(.*?)"$/) do |branch|
   run_in_dir("git checkout #{branch}")
 end
 
-And(/^I install the AutoGrader gems$/) do
+When(/^I install the AutoGrader gems$/) do
   run_process('bundle install', @dir, true)
 end
-
-## Then Steps
 
 Then(/^I should see no difference$/) do
   run_in_dir("git diff origin/#{@branch}")
   expect(@test_output == '').to be_true
-  #puts "'#{@dir}' matches origin/#{@branch} branch"
 end
-
-
-And(/^I should see (\d+) gems$/) do |num|
-  run_process('bundle list', @dir, true)
-  expect(@test_output.lines.select{|x| x.match /\*/}).to have(num).gems
-end
-
-# duplicate steps from hw_testing_steps
 
 Then(/^I should see that there are no errors$/) do
   expect(@test_status).to be_success
-end
-
-Then(/I should see the execution results$/) do
-  puts @test_status
-  puts @test_errors
-  puts @test_output
 end


### PR DESCRIPTION
- removed unused cruft
- use one-line raise for custom cucumber error, like LocalSupport, which also makes the text red
