### PR TITLE
Adding some tests and fixes

### DIFF
--- a/features/git_immersion_testing.feature
+++ b/features/git_immersion_testing.feature
@@ -16,5 +16,16 @@ Feature: Testing instructor created homeworks
     | non-forked repo         | solutions/tansaku.txt   | autograder/mvp_spec.rb | Score out of 100: 70 | tansaku         |
     | non-forked, > 6 commits | solutions/apelade.txt   | autograder/mvp_spec.rb | Score out of 100: 90 | apelade         |
 
+  Scenario: Check GitHub api key is configured
+    Given I have a valid token set in environment variable "GIT_IMMERSION_TOKEN"
+    # I put mine in /etc/environment
+    When I check my remaining rate limit
+    Then I should see it is a number, not nil
+
+  Scenario: Confirm code uses that api key, not anonymous
+    Given I have tests and token set up
+    When I repeat the test of "apelade.txt" against autograder "mvp_spec.rb" for 2 times
+    Then I should see my remaining rate limit has declined a few times more than that
+
     # TODO ideally we should be stubbing the octokit gem ... use https://github.com/vcr/vcr ?
     # TODO Local or git repos that will never disappear ?

--- a/features/git_immersion_testing.feature
+++ b/features/git_immersion_testing.feature
@@ -12,9 +12,9 @@ Feature: Testing instructor created homeworks
     And I should see the execution results with <test_title>
   Examples:
     | test_title              | test_subject            | spec                   | overall_score        | github_username |
-    | forked repo             | solutions/jhasson84.txt | autograder/mvp_spec.rb | Score out of 100: 0  | jhasson84       |
-    | non-forked repo         | solutions/tansaku.txt   | autograder/mvp_spec.rb | Score out of 100: 12 | tansaku         |
-    | non-forked, > 6 commits | solutions/apelade.txt   | autograder/mvp_spec.rb | Score out of 100: 67 | apelade         |
+    | forked repo             | solutions/jhasson84.txt | autograder/mvp_spec.rb | Score out of 100: 40 | jhasson84       |
+    | non-forked repo         | solutions/tansaku.txt   | autograder/mvp_spec.rb | Score out of 100: 70 | tansaku         |
+    | non-forked, > 6 commits | solutions/apelade.txt   | autograder/mvp_spec.rb | Score out of 100: 90 | apelade         |
 
     # TODO ideally we should be stubbing the octokit gem ... use https://github.com/vcr/vcr ?
     # TODO Local or git repos that will never disappear ?

--- a/features/step_definitions/git_immersion_testing_steps.rb
+++ b/features/step_definitions/git_immersion_testing_steps.rb
@@ -1,17 +1,17 @@
 require 'open3'
+require 'octokit'
 
 def run_ag(subject, spec)
   git_user = File.read(subject).strip
   cli_string = "./new_grader -t GithubRspecGrader #{git_user} ../#{spec}"
-  #cli_string = cli_string.gsub("\n", ' ')
   run_process cli_string
 end
 
 def run_process(cli_string, dir=@autograders)
   @test_output, @test_errors, @test_status = Open3.capture3(
-      { 'BUNDLE_GEMFILE' => 'Gemfile' }, cli_string, :chdir => dir
+      {'BUNDLE_GEMFILE' => 'Gemfile'}, cli_string, :chdir => dir
   )
-  raise ( @test_output + @test_errors + @test_status.to_s ) unless @test_status.success?
+  raise (cli_string + @test_output + @test_errors + @test_status.to_s) unless @test_status.success?
 end
 
 Given(/^I have the homework in "(.*?)"$/) do |hw|
@@ -36,3 +36,46 @@ And(/^I should see the execution results with (.*)$/) do |test_title|
   success = @test_status.success? ? 'Success' : 'Failure'
   puts success + '!'
 end
+
+
+Given(/^I have a valid token set in environment variable "([^"]*)"$/) do |var|
+  @token = ENV["#{var}"]
+  expect(@token).not_to be_nil
+end
+
+When(/^I check my remaining rate limit$/) do
+  @client = Octokit::Client.new(:access_token => @token)
+  expect(@client).not_to be_nil
+  expect { @remaining_limit = @client.rate_limit.remaining }.not_to raise_error
+end
+
+Then(/^I should see it is a number, not nil$/) do
+  puts "remaining rate limit per hour: #{@remaining_limit}"
+  expect(@remaining_limit).not_to be_nil
+  expect(@remaining_limit).to be_integer
+end
+
+
+Given(/^I have tests and token set up$/) do
+  steps %Q{
+    Given I have a valid token set in environment variable "GIT_IMMERSION_TOKEN"
+    And I have the homework in "git-immersion"
+    And AutoGraders are in "rag"
+  }
+end
+
+When(/^I repeat the test of "(.*)" against autograder "(.*)" for (\d+) times$/) do |subject, spec, reps|
+  @num_runs = reps.to_i
+  @client = Octokit::Client.new(:access_token => @token)
+  @start_limit = @client.rate_limit.remaining
+  expect { @num_runs.times { run_ag("#{@hw_path}/solutions/#{subject}", "#{@hw_path}/autograder/#{spec}") } }.not_to raise_error
+end
+
+Then(/^I should see my remaining rate limit has declined a few times more than that$/) do
+  remaining = Octokit::Client.new(:access_token => @token).rate_limit.remaining
+  decline = @start_limit - remaining
+  puts "remaining rate limit #{remaining} declined by #{decline} in #{@num_runs} runs"
+  expect(decline).to be > @num_runs
+  expect(decline % @num_runs).to be 0
+end
+

--- a/git-immersion/autograder/mvp_spec.rb
+++ b/git-immersion/autograder/mvp_spec.rb
@@ -1,39 +1,44 @@
 require 'octokit'
 require 'rspec'
 
+
 describe "Github" do
 
+  # START_DATE = '2014-01-01'
+  START_DATE = Date.today << 12 # months
+
+  # This ENV var comes from GithubRspecGrader
+  USER_REPO = ENV['GITHUB_USERNAME']+'/gitimmersion'
+
   before (:all) do
-    # TODO AgileVentures key. Do these expire??
     # Rate limit is 5000/hr
     # This ENV var comes from travis env:global:secure or set by admin
-    # PAULS_GIT_IMMERSION_TOKEN is configured to allow only read of public access data
+    # TODO Do these expire??
+    # GIT_IMMERSION_TOKEN is configured to allow only read of public access data
     @token = ENV['GIT_IMMERSION_TOKEN']
-    #START_DATE = '2014-01-01'
-    @start_date = Date.today << 12 # months
-
-    # This ENV var comes from GithubRspecGrader
-    @user_repo = ENV['GITHUB_USERNAME']+'/gitimmersion'
-
     @client = Octokit::Client.new(:access_token => @token)
-    @commits =  @client.commits_since(@user_repo, @start_date)
-    @client.repository(@user_repo).parent.should be_nil
+    @commits =  @client.commits_since(USER_REPO, START_DATE)
   end
 
-  it "should find a repository on github for: #{@user_repo} [5 points]" do
-    (@client.repository? @user_repo).should be_true
+
+  it "should find a repository on github for: #{USER_REPO} [20 points]" do
+    (@client.repository? USER_REPO).should be_true
+  end
+
+  it "should be a freshly created repo, not a fork  [50 points]" do
+    @client.repository(USER_REPO).parent.should be_nil
   end
 
   #TODO point per commit is possible?
-  it "should have at least 3 commits since #{@start_date} [10 points]" do
+  it "should have at least 3 commits since #{START_DATE} [10 points]" do
     @commits.count.should be > 3
   end
 
-  it "should have at least 6 commits since #{@start_date} [15 points]" do
+  it "should have at least 6 commits since #{START_DATE} [10 points]" do
     @commits.count.should be > 6
   end
 
-  it "should have at least 9 commits since #{@start_date} [15 points]" do
+  it "should have at least 9 commits since #{START_DATE} [10 points]" do
     @commits.count.should be > 9
   end
 


### PR DESCRIPTION
CONSTANTS in autograder/mvp_spec.rb require block that should give better feedbaack in edx, as well as test that a) env has the git token, and b) that the code actually uses it instead of using the low rate limit of 60 hits/hr

but no new functionality to the grader :(
Richard Ilson suggested fuzzy matching the commit messages
