### PR TITLE
Make CI work on pull requests from developer forks, provide messages about needed ENV vars

### DIFF
--- a/features/git_immersion_testing.feature
+++ b/features/git_immersion_testing.feature
@@ -17,15 +17,15 @@ Feature: Testing instructor created homeworks
     | non-forked, > 6 commits | solutions/apelade.txt   | autograder/mvp_spec.rb | Score out of 100: 90 | apelade         |
 
   Scenario: Check GitHub api key is configured
-    Given I have a valid token set in environment variable "GIT_IMMERSION_TOKEN"
-    # I put mine in /etc/environment
+    Given I must rely on anonymous Octokit calls if running Travis CI on a pull request from a fork
+    And Or I have a valid token set in environment variable "GIT_IMMERSION_TOKEN"
     When I check my remaining rate limit
     Then I should see it is a number, not nil
 
   Scenario: Confirm code uses that api key, not anonymous
     Given I have tests and token set up
-    When I repeat the test of "apelade.txt" against autograder "mvp_spec.rb" for 2 times
-    Then I should see my remaining rate limit has declined a few times more than that
+    When I repeat the test of "apelade.txt" against autograder "mvp_spec.rb"
+    Then I should see my remaining rate limit has declined
 
     # TODO ideally we should be stubbing the octokit gem ... use https://github.com/vcr/vcr ?
     # TODO Local or git repos that will never disappear ?

--- a/features/step_definitions/git_immersion_testing_steps.rb
+++ b/features/step_definitions/git_immersion_testing_steps.rb
@@ -12,6 +12,7 @@ def run_process(cli_string, dir=@autograders)
       {'BUNDLE_GEMFILE' => 'Gemfile'}, cli_string, :chdir => dir
   )
   raise (cli_string + @test_output + @test_errors + @test_status.to_s) unless @test_status.success?
+  puts "\n" + @test_errors if ( @test_errors != '' && @test_status.success? )
 end
 
 Given(/^I have the homework in "(.*?)"$/) do |hw|
@@ -38,14 +39,27 @@ And(/^I should see the execution results with (.*)$/) do |test_title|
 end
 
 
-Given(/^I have a valid token set in environment variable "([^"]*)"$/) do |var|
+Given(/^I must rely on anonymous Octokit calls if running Travis CI on a pull request from a fork$/) do
+  @travis_pull_request_from_fork =  (ENV['TRAVIS_SECURE_ENV_VARS'] == 'true') && (ENV['TRAVIS_PULL_REQUEST'] != 'false')
+  if @travis_pull_request_from_fork
+    puts "Travis operating on a pull request from a fork. Secure env variables are not permitted.\n" +
+         "Using nil ENV['GIT_IMMERSION_TOKEN']: anonymous Octokit calls with a rate limit of 60/hr.\n"+
+         "Beware of exceeding the Github API rate limit from repeating the tests / pull request builds from forks!"
+  end
+end
+
+And(/^Or I have a valid token set in environment variable "([^"]*)"$/) do |var|
+  #It's OK if this is nil because it will then create the anonymous client
   @token = ENV["#{var}"]
-  expect(@token).not_to be_nil
+  if @token.nil? and not @travis_pull_request_from_fork
+    puts "Go add an environment variable to your machine or secure env variable to travis.\n"+
+         "See https://github.com/AgileVentures/AutoGraderExamples/blob/master/README.md"
+  end
+  @client = Octokit::Client.new(:access_token => @token)
+  expect(@client).not_to be_nil
 end
 
 When(/^I check my remaining rate limit$/) do
-  @client = Octokit::Client.new(:access_token => @token)
-  expect(@client).not_to be_nil
   expect { @remaining_limit = @client.rate_limit.remaining }.not_to raise_error
 end
 
@@ -58,24 +72,28 @@ end
 
 Given(/^I have tests and token set up$/) do
   steps %Q{
-    Given I have a valid token set in environment variable "GIT_IMMERSION_TOKEN"
+    Given I must rely on anonymous Octokit calls if running Travis CI on a pull request from a fork
+    And Or I have a valid token set in environment variable "GIT_IMMERSION_TOKEN"
     And I have the homework in "git-immersion"
     And AutoGraders are in "rag"
   }
 end
 
-When(/^I repeat the test of "(.*)" against autograder "(.*)" for (\d+) times$/) do |subject, spec, reps|
-  @num_runs = reps.to_i
+When(/^I repeat the test of "(.*)" against autograder "(.*)"$/) do |subject, spec|
+  # Do not set it to run very many times because it will be limited
+  # to 60 hits per hour when Travis is running a pull request from a fork!
+  @num_runs = 1
   @client = Octokit::Client.new(:access_token => @token)
   @start_limit = @client.rate_limit.remaining
   expect { @num_runs.times { run_ag("#{@hw_path}/solutions/#{subject}", "#{@hw_path}/autograder/#{spec}") } }.not_to raise_error
 end
 
-Then(/^I should see my remaining rate limit has declined a few times more than that$/) do
+Then(/^I should see my remaining rate limit has declined$/) do
+  #TODO why must the client be re-init here?
+  #remaining = @client.rate_limit.remaining
   remaining = Octokit::Client.new(:access_token => @token).rate_limit.remaining
   decline = @start_limit - remaining
-  puts "remaining rate limit #{remaining} declined by #{decline} in #{@num_runs} runs"
+  puts "remaining rate limit: #{remaining}, declined by #{decline} in #{@num_runs} runs"
   expect(decline).to be > @num_runs
   expect(decline % @num_runs).to be 0
 end
-

--- a/features/step_definitions/git_immersion_testing_steps.rb
+++ b/features/step_definitions/git_immersion_testing_steps.rb
@@ -40,7 +40,7 @@ end
 
 
 Given(/^I must rely on anonymous Octokit calls if running Travis CI on a pull request from a fork$/) do
-  @travis_pull_request_from_fork =  (ENV['TRAVIS_SECURE_ENV_VARS'] == 'true') && (ENV['TRAVIS_PULL_REQUEST'] != 'false')
+  @travis_pull_request_from_fork =  (ENV['TRAVIS_SECURE_ENV_VARS'] == 'false') && (ENV['TRAVIS_PULL_REQUEST'] != 'false')
   if @travis_pull_request_from_fork
     puts "Travis operating on a pull request from a fork. Secure env variables are not permitted.\n" +
          "Using nil ENV['GIT_IMMERSION_TOKEN']: anonymous Octokit calls with a rate limit of 60/hr.\n"+


### PR DESCRIPTION
- Use anonymous Octokit calls up to 60/hr if it detects a pull request from a developer fork which do not permit travis secure environment variables.
- Also if there is not a secure key in .travis.yml for them
- Refers to doco about how to do the travis-encrypted GitHub API key and environment variable
- mvp_spec.rb raises error for invalid key and provides warnings for nil key, which still works
- This will be a good test to see if it works
